### PR TITLE
Fix ERC20 constructor and SPDX comments

### DIFF
--- a/contracts/MyERC20.sol
+++ b/contracts/MyERC20.sol
@@ -15,7 +15,6 @@ contract MyERC20 is ERC20, Ownable, ERC20Permit, ERC20Votes, AccessControl {
     constructor() ERC20("MyERC20", "ME2") ERC20Permit("MyERC20") {
         // トークンを作成者に1000000渡す
         _mint(msg.sender, 1000000);
-        Ownable(msg.sender);
         _grantRole(MINTER_ROLE, msg.sender);
     }
 

--- a/contracts/MyERC721.sol
+++ b/contracts/MyERC721.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICNSED
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/AccessControl.sol";

--- a/contracts/MyToken.sol
+++ b/contracts/MyToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identitfier: UNLICENSED
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.0;
 
 contract MyToken {


### PR DESCRIPTION
## Summary
- fix ERC20 constructor so owner is correctly initialized
- correct SPDX license headers in token contracts

## Testing
- `npx hardhat test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/hardhat)*

------
https://chatgpt.com/codex/tasks/task_e_685690c54f5083219f55cd85794783d0